### PR TITLE
Ad IDs to the redocusaurus config to name the download filenames

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -47,12 +47,12 @@ const config = {
         // Plugin Options for loading OpenAPI files
         specs: [
           {
-            id: 'infosum-v1-swagger',
+            id: 'infosum-openapi-v1',
             spec: 'static/tyrael.swagger.json',
             route: '/api/v1'
           },
           {
-            id: 'infosum-v2-swagger',
+            id: 'infosum-openapi-v2',
             spec: 'static/swagger.json',
             route: '/api/v2'
           },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -47,10 +47,12 @@ const config = {
         // Plugin Options for loading OpenAPI files
         specs: [
           {
+            id: 'infosum-v1-swagger',
             spec: 'static/tyrael.swagger.json',
             route: '/api/v1'
           },
           {
+            id: 'infosum-v2-swagger',
             spec: 'static/swagger.json',
             route: '/api/v2'
           },


### PR DESCRIPTION
Renames the downloaded openapi/swagger yaml files by assigning IDs to each spec in redocusaurus